### PR TITLE
Add timestamp to pub.timestamp column

### DIFF
--- a/oip042/publisher.go
+++ b/oip042/publisher.go
@@ -57,6 +57,7 @@ func (rp RegisterPub) Store(context OipContext) error {
 		// these values are only set on publish
 		cv["active"] = 1
 		cv["unixtime"] = rp.Timestamp
+		cv["timestamp"] = rp.Timestamp
 		cv["txid"] = context.TxId
 		cv["block"] = context.BlockHeight
 		q = squirrel.Insert("pub").SetMap(cv)


### PR DESCRIPTION
Add value to pub.timestamp which overcomes the constraint error placed in create table command.